### PR TITLE
Add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/.github			export-ignore
+/tests				export-ignore
+.gitattributes		export-ignore
+.gitignore			export-ignore
+contributors.txt	export-ignore


### PR DESCRIPTION
When I do `composer require granam/czech-vocative` it downloads whole repository to vendor folder. Including tests folder etc.

With this file, some files will be ignored to return only what is really needed.